### PR TITLE
Fix npm run watch command in windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "watch": "./node_modules/watchify/bin/cmd.js src/app.js -t [ babelify --presets [ es2015 react ] ] -o public/js/bundle.js -v"
+    "watch": "watchify src/app.js -t [ babelify --presets [ es2015 react ] ] -o public/js/bundle.js -v"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
When I run the command `npm run watch` on windows, I have this error : 
'.' is not recognized as an internal or external command, operable program or batch file.

To fix that and make it works on every platform, we can just call watchify directly instead of the complete path.